### PR TITLE
Minor fixes in docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -82,9 +82,8 @@ The five Turn endpoints of the Turn entity are used to move the turn in the foll
 
 You can find the full API spec [here](docs/api_spec.json) in Open API format.
 
-Additionally, when you [run the system](#run) you can interact with the API
-documentation using Swagger UI [here](http://localhost:8000/swagger-ui.html).
-
+Additionally, **after** you [run](#run) the system locally you can interact with
+the API documentation using Swagger UI [here](http://localhost:8000/swagger-ui.html).
 
 ## Tests
 

--- a/frontend/noq/README.md
+++ b/frontend/noq/README.md
@@ -40,6 +40,8 @@ The frontend shows different views depending on the role of an authenticated use
 
 ## Public views
 
+The only public view is the login.
+
 ### Login
 
 ![Login](docs/1-login.png)


### PR DESCRIPTION
Changes:

1. Backend README: Be more explicit about how to access the API docs
1. Frontend README: Indicate that login is the only public view