### PR TITLE
Bugfix: inject values from properties

### DIFF
--- a/backend/src/main/java/com/jespinel/noq/notifications/TwilioSmsNotifier.java
+++ b/backend/src/main/java/com/jespinel/noq/notifications/TwilioSmsNotifier.java
@@ -29,7 +29,9 @@ public class TwilioSmsNotifier implements ISmsNotifier {
     @Override
     public void send(String phoneNumber, String message) {
         PhoneNumber to = new PhoneNumber(phoneNumber);
-        Message sentMessage = Message.creator(to, sender, message).create();
+        Message sentMessage = Message
+                .creator(to, sender, message)
+                .create();
         logger.debug("TWILIO: Message sent to %s, message sid %s".
                 formatted(phoneNumber, sentMessage.getSid()));
     }

--- a/backend/src/main/java/com/jespinel/noq/notifications/TwilioSmsNotifier.java
+++ b/backend/src/main/java/com/jespinel/noq/notifications/TwilioSmsNotifier.java
@@ -15,18 +15,13 @@ import org.springframework.stereotype.Service;
 )
 public class TwilioSmsNotifier implements ISmsNotifier {
 
-    @Value("${twilio.account.sid}")
-    private String sid;
-
-    @Value("${twilio.account.token}")
-    private String token;
-
-    @Value("${twilio.sender.number}")
-    private String senderNumber;
-
     private final PhoneNumber sender;
 
-    public TwilioSmsNotifier() {
+    public TwilioSmsNotifier(
+            @Value("${twilio.account.sid}") String sid,
+            @Value("${twilio.account.token}") String token,
+            @Value("${twilio.sender.number}") String senderNumber
+    ) {
         Twilio.init(sid, token);
         sender = new PhoneNumber(senderNumber);
     }


### PR DESCRIPTION
**Description**

In the `TwilioSmsNotifier` the following fields were `null`:
* `sid`
* `token`
* `senderNumber`

This PR is fixing that bug. Now the properties get the value from `applicaton.properties`.